### PR TITLE
NullPointerException in getOldestRecordTimeInMillis 

### DIFF
--- a/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducer.java
+++ b/java/amazon-kinesis-producer/src/main/java/com/amazonaws/services/kinesis/producer/KinesisProducer.java
@@ -672,10 +672,12 @@ public class KinesisProducer implements IKinesisProducer {
      */
     @Override
     public long getOldestRecordTimeInMillis() {
-        if (oldestFutureTrackerHeap.isEmpty()) {
+        SettableFutureTracker oldestFuture = oldestFutureTrackerHeap.peek();
+
+        if (oldestFuture == null) {
             return 0;
         }
-        return Instant.now().toEpochMilli() - oldestFutureTrackerHeap.peek().getTimestamp().toEpochMilli();
+        return Instant.now().toEpochMilli() - oldestFuture.getTimestamp().toEpochMilli();
     }
 
     /**

--- a/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/KinesisProducerTest.java
+++ b/java/amazon-kinesis-producer/src/test/java/com/amazonaws/services/kinesis/producer/KinesisProducerTest.java
@@ -290,4 +290,16 @@ public class KinesisProducerTest {
         }
         return new KinesisProducer(cfg);
     }
+
+    @Test
+    public void getOldestRecordTimeInMillisShouldReturn0WhenNoFuturesInHeap() {
+        // Given that there are no futures in the heap,
+        IKinesisProducer candidate = getProducer(null, null);
+
+        // When we call getOldestRecordTimeInMillis,
+        long actual = candidate.getOldestRecordTimeInMillis();
+
+        // Then we expect it to return 0.
+        assertEquals(0L, actual);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:* [489](https://github.com/awslabs/amazon-kinesis-producer/issues/489)

*Description of changes:*
- Refactored `getOldestRecordTimeInMillis` to avoid a possible `NullPointerException` which can be caused by a race condition
- Added a simple unit test for this method

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
